### PR TITLE
Fix authors for IMO1985P4

### DIFF
--- a/Compfiles/Imo1985P4.lean
+++ b/Compfiles/Imo1985P4.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 The Compfiles Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:　Benpigchu
+Authors: Benpigchu
 -/
 
 import Mathlib


### PR DESCRIPTION
I accidentally used a full-width space in the author field in last PR, which prevents the website builder from parsing this correctly