### PR TITLE
Fix some usa problems

### DIFF
--- a/Compfiles/Usa1972P3.lean
+++ b/Compfiles/Usa1972P3.lean
@@ -13,8 +13,10 @@ problem_file { tags := [.Combinatorics, .NumberTheory] }
 /-!
 # USA Mathematical Olympiad 1972, Problem 3
 
-n digits, none of them 0, are randomly (and independently) generated,
-find the probability that their product is divisible by 10.
+A random number selector can only select one of the nine integers 1, 2, ..., 9,
+and it makes these selections with equal probability. Determine the probability
+that after n selections, where n > 1, the product of the n numbers selected will
+be divisible by 10.
 -/
 
 namespace Usa1972P3
@@ -30,9 +32,9 @@ def is_good_seq {n : ℕ} (s : DigitSeq n) := 10 ∣ ∏a, to_nat_digit (s a)
 def good_seqs {n : ℕ} := {s : DigitSeq n | is_good_seq s}
 
 noncomputable determine solution (n : ℕ) : ENNReal :=
-  1 - (8 / 9) ^ n - (5 / 9) ^ n + (4 / 9) ^ n
+  1 + (4 / 9) ^ n - (8 / 9) ^ n - (5 / 9) ^ n
 
-problem usa1972_p3 (n : ℕ) (digits : DigitSeq n) :
+problem usa1972_p3 (n : ℕ) (_hn : 1 < n) :
   (unifDistN n).toOuterMeasure good_seqs = solution n := sorry
 
 end Usa1972P3

--- a/Compfiles/Usa1999P1.lean
+++ b/Compfiles/Usa1999P1.lean
@@ -39,6 +39,7 @@ problem usa1999_p1 (n : ℕ) (c : Finset (checkerboard n))
     (ha : ∀ x : checkerboard n, x ∈ c ∨ (∃ y ∈ c, adjacent x y))
     (hb : ∀ x ∈ c, ∀ y ∈ c,
       ∃ p : List (checkerboard n),
+        (∀ z, z ∈ p → z ∈ c) ∧
         List.IsChain adjacent p ∧
         List.head? p = x ∧
         List.getLast? p = y) :

--- a/Compfiles/Usa2017P5.lean
+++ b/Compfiles/Usa2017P5.lean
@@ -18,7 +18,7 @@ a labeling of the lattice points in ℤ² with positive integers for which:
 
   1. only finitely many distinct labels occur, and
   2. for each label i, the distance between any two points labeled i
-     is at most cⁱ.
+     is at least cⁱ.
 -/
 
 namespace Usa2017P5
@@ -35,7 +35,7 @@ problem usa2017_p5 (c : ℝ) :
        (Set.range l).Finite ∧
        (∀ p, 0 < l p) ∧
        ∀ {p1 p2}, p1 ≠ p2 → (l p1 = l p2) →
-            dist (l p1) (l p2) ≤ c ^ (l p1)) := by
+            c ^ (l p1) ≤ dist p1 p2) := by
   sorry
 
 

--- a/Compfiles/Usa2024P2.lean
+++ b/Compfiles/Usa2024P2.lean
@@ -14,8 +14,8 @@ problem_file { tags := [.Combinatorics] }
 /-!
 # USA Mathematical Olympiad 2024, Problem 2
 
-Let S₁, S₂, ..., Sₙ be finite sets of integers whose intersection
-is not empty. For each non-empty T ⊆ {S₁, S₂, ..., Sₙ}, the size of
+Let S₁, S₂, ..., S₁₀₀ be finite sets of integers whose intersection
+is not empty. For each non-empty T ⊆ {S₁, S₂, ..., S₁₀₀}, the size of
 the intersection of the sets in T is a multiple of the number of
 sets in T. What is the least possible number of elements that are in
 at least 50 sets?
@@ -29,16 +29,16 @@ structure Good (S : Fin 100 → Set ℤ) : Prop where
   finite : ∀ i, (S i).Finite
   nonempty_inter : ⋂ i, S i ≠ ∅
   card : ∀ T : Finset (Fin 100), T.Nonempty →
-                 ∃ k : ℕ, (⋂ i ∈ T, S i).ncard * k = T.card
+                 ∃ k : ℕ, (⋂ i ∈ T, S i).ncard = k * T.card
 
 -- z is in at least k of the sets S.
 abbrev InAtLeastKSubsets (S : Fin 100 → Set ℤ) (k : ℕ) (z : ℤ) : Prop :=
   k ≤ {i : Fin 100 | z ∈ S i }.ncard
 
-problem usa2024_p2 (n : ℕ) :
+problem usa2024_p2 :
     IsLeast
       { k | ∃ S, Good S ∧
-             k = {z : ℤ | InAtLeastKSubsets S k z }.ncard } solution :=
+             k = {z : ℤ | InAtLeastKSubsets S 50 z }.ncard } solution :=
   by sorry
 
 


### PR DESCRIPTION
Fixes small statement issues in several USA problem formalizations:
  - Usa2024P2
  - Usa2017P5
  - Usa1972P3
  - Usa1999P1

Notes:

For Usa1972P3, the positive term in the solution expression is now placed before the subtractions because ENNReal subtraction truncates at 0.

For Usa1999P1 require the connecting checker path to use only occupied squares