### PR TITLE
[Imo2017P6] fix statement: sum should include the x^n term

### DIFF
--- a/Compfiles/Imo2017P6.lean
+++ b/Compfiles/Imo2017P6.lean
@@ -28,7 +28,7 @@ namespace Imo2017P6
 
 problem imo2017_p6 (S : Finset (ℤ × ℤ)) (hS : ∀ s ∈ S, gcd s.1 s.2 = 1) :
     ∃ n : ℕ, 0 < n ∧ ∃ a : ℕ → ℤ,
-      ∀ s ∈ S, ∑ i ∈ Finset.range n, a i * s.1 ^ i * s.2 ^ (n - i) = 1 := by
+      ∀ s ∈ S, ∑ i ∈ Finset.range (n + 1), a i * s.1 ^ i * s.2 ^ (n - i) = 1 := by
   sorry
 
 


### PR DESCRIPTION
The current statement is false as written: the sum over `Finset.range n` stops at i = n-1, so every term has a factor `s.2 ^ (n - i)` with n - i ≥ 1. Taking S = {(1, 0)} (primitive, since gcd 1 0 = 1) the sum is 0 for every choice of n and a, never 1. With `range (n + 1)` the i = n term `a n * x ^ n` is included, matching the doc comment (`a₀xⁿ + a₁xⁿ⁻¹y + ... + aₙyⁿ`) and the original problem.